### PR TITLE
20.08 fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,7 @@ class MovieMaster(MycroftSkill):
 		# Set the language from the default in settings
 		TMDB.language = self.lang
 
-		self.settings.settings_change_callback = self.on_web_settings_change
+		self.settings_change_callback = self.on_web_settings_change
 
 	def on_web_settings_change(self):
 		api = self.settings.get("apiv3")

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,5 +1,4 @@
 {
-    "name": "Movie Master",
     "skillMetadata": {
         "sections": [
 	    {


### PR DESCRIPTION
Hi @builderjer, 

Two quick fixes that I noticed during testing for the 20.08 rollover.
1. The settings callback is now directly on the MycroftSkill class.
2. The Skill name field in settingsmeta has been deprecated. We now pull this straight from the README so that it's consistent with other places where the name is presented.